### PR TITLE
[PVR] Echo up important Status info to Timer Rules

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -9491,7 +9491,15 @@ msgctxt "#19241"
 msgid "The PVR manager has been enabled without any enabled PVR add-on. Enable at least one add-on in order to use the PVR functionality."
 msgstr ""
 
-#empty strings from id 19242 to 19243
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
+msgctxt "#19242"
+msgid "%d will record"
+msgstr ""
+
+#: xbmc/pvr/timers/PVRTimerInfoTag.cpp
+msgctxt "#19243"
+msgid "Completed"
+msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#19244"

--- a/xbmc/pvr/timers/PVRTimerInfoTag.h
+++ b/xbmc/pvr/timers/PVRTimerInfoTag.h
@@ -239,6 +239,10 @@ namespace PVR
     int                   m_iClientId;           /*!< @brief ID of the backend */
     unsigned int          m_iClientIndex;        /*!< @brief index number of the tag, given by the backend, PVR_TIMER_NO_CLIENT_INDEX for new */
     unsigned int          m_iParentClientIndex;  /*!< @brief for timers scheduled by repeated timers, the index number of the parent, given by the backend, PVR_TIMER_NO_PARENT for no parent */
+    unsigned int          m_iActiveChildTimers;  /*!< @brief Number of active timers which have this timer as their m_iParentClientIndex */
+    bool                  m_bHasChildConflictNOK; /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_CONFLICT_NOK */
+    bool                  m_bHasChildRecording;  /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_RECORDING */
+    bool                  m_bHasChildErrors;     /*!< @brief Has at least one child timer with status PVR_TIMER_STATE_ERROR */
     int                   m_iClientChannelUid;   /*!< @brief channel uid */
     bool                  m_bStartAnyTime;       /*!< @brief Ignore start date and time clock. Record at 'Any Time' */
     bool                  m_bEndAnyTime;         /*!< @brief Ignore end date and time clock. Record at 'Any Time' */


### PR DESCRIPTION
- Number of 'Will Record' Child Timers
- Presence of InProg Child Timers
- Presence of Conflict_NOK or Error Child Timers

Also adds 'Completed' status as distinct from 'Enabled'
![screenshot037](https://cloud.githubusercontent.com/assets/12870817/12071357/93f10002-b09f-11e5-93b2-eef4388a54db.png)

No sure how this will play with all existing pvr clients, but I can't see it breaking anything.
Small tweaks may need to be made to the reported status of 'Timer Rules' in each client to get it to work fully as intended. I'm hoping the logic is sound so it should just 'work'.

If a client already echos up 'Conflict / Error / Recording' status the behaviour should be unchanged. 
Only a status of 'NEW' or 'SCHEDULED' and in the case of recording in prog, 'COMPLETED' will be replaced with the new information based on child timer states.
(I made some changes to pvr.mythtv to get 'COMPLETED' to work as shown which I will PR if this is accepted)

I'm a little uncomfortable about putting the child timer status reset in CPVRTimerInfoTag::UpdateEntry and the updates in CPVRTimers::UpdateEntries. Happy to move it all to CPVRTimers::UpdateEntries if there are strong opinions.

pings: @ksooo, @ryangribble, @janbar, @jalle19
