### PR TITLE
[Weather] Fix home window not reset when current add-on is uninstalled

### DIFF
--- a/addons/skin.estuary/language/resource.language.en_gb/strings.po
+++ b/addons/skin.estuary/language/resource.language.en_gb/strings.po
@@ -864,7 +864,12 @@ msgctxt "#31176"
 msgid "Default select action for movie sets on the home screen"
 msgstr ""
 
-#empty strings from id 31177 to 31596
+#: /xml/SkinSettings.xml
+msgctxt "#31177"
+msgid "Choose weather icon pack"
+msgstr ""
+
+#empty strings from id 31178 to 31596
 
 #: /xml/Includes_SettingsDialog.xml
 #. Button to select Player Process Info window

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -624,6 +624,24 @@
 								<width>100%</width>
 								<texture border="21">dialogs/dialog-bg.png</texture>
 							</control>
+							<control type="group">
+								<visible>!Weather.IsFetched + Weather.IsUpdating</visible>
+								<top>90</top>
+								<left>600</left>
+								<control type="image">
+									<width>100</width>
+									<height>100</height>
+									<aspectratio aligny="center">keep</aspectratio>
+									<texture colordiffuse="black">dialogs/extendedprogress/loading-back.png</texture>
+								</control>
+								<control type="image">
+									<width>100</width>
+									<height>100</height>
+									<aspectratio aligny="center">keep</aspectratio>
+									<texture>dialogs/extendedprogress/loading.png</texture>
+									<animation effect="rotate" center="auto" start="360" end="0" time="1500" loop="true" condition="true">Conditional</animation>
+								</control>
+							</control>
 							<control type="label">
 								<left>840</left>
 								<top>60</top>

--- a/addons/skin.estuary/xml/Home.xml
+++ b/addons/skin.estuary/xml/Home.xml
@@ -652,8 +652,7 @@
 								<right>60</right>
 								<align>right</align>
 								<font>font14</font>
-								<label>$INFO[Weather.Data(Current.Temperature)]$INFO[System.TemperatureUnits]</label>
-								<visible>![String.IsEmpty(Weather.Data(Current.Temperature))]</visible>
+								<label>$INFO[Weather.Data(Current.Temperature)]</label>
 							</control>
 							<control type="grouplist">
 								<top>50</top>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -1131,8 +1131,8 @@
 						<height>50</height>
 						<width>auto</width>
 						<aligny>center</aligny>
-						<label>$INFO[Weather.Data(Current.Temperature)]$INFO[System.TemperatureUnits]</label>
-						<visible>Skin.HasSetting(show_weatherinfo) + Weather.IsFetched + ![String.IsEmpty(Weather.Data(Current.Temperature))]</visible>
+						<label>$INFO[Weather.Data(Current.Temperature)]</label>
+						<visible>Skin.HasSetting(show_weatherinfo) + Weather.IsFetched</visible>
 					</control>
 					<control type="image">
 						<top>1</top>

--- a/addons/skin.estuary/xml/Includes.xml
+++ b/addons/skin.estuary/xml/Includes.xml
@@ -1133,6 +1133,7 @@
 						<aligny>center</aligny>
 						<label>$INFO[Weather.Data(Current.Temperature)]</label>
 						<visible>Skin.HasSetting(show_weatherinfo) + Weather.IsFetched</visible>
+						<visible>!Window.IsActive(weather) + [!Window.IsActive(home) | !String.IsEqual(Container(9000).ListItem.Property(id),weather)]</visible>
 					</control>
 					<control type="image">
 						<top>1</top>
@@ -1142,6 +1143,7 @@
 						<aspectratio aligny="center" align="left">keep</aspectratio>
 						<texture>$INFO[Weather.Data(Current.FanartCode),weather/small/,.png]</texture>
 						<visible>Skin.HasSetting(show_weatherinfo) + Weather.IsFetched + ![String.IsEqual(Weather.Data(Current.FanartCode),na)]</visible>
+						<visible>!Window.IsActive(weather) + [!Window.IsActive(home) | !String.IsEqual(Container(9000).ListItem.Property(id),weather)]</visible>
 					</control>
 					<control type="image">
 						<top>8</top>

--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -654,12 +654,16 @@
 							<bordertexture border="21" infill="false">overlays/shadow.png</bordertexture>
 							<bordersize>20</bordersize>
 						</control>
-						<control type="image">
+						<control type="multiimage">
 							<left>60</left>
 							<top>108</top>
 							<width>130</width>
 							<height>130</height>
-							<texture>$INFO[ListItem.Icon]</texture>
+							<imagepath>$INFO[ListItem.Icon]</imagepath>
+							<aspectratio>keep</aspectratio>
+							<timeperimage>20</timeperimage>
+							<fadetime>10</fadetime>
+							<randomize>false</randomize>
 						</control>
 						<control type="label">
 							<left>15</left>
@@ -714,12 +718,16 @@
 							<bordersize>20</bordersize>
 							<include>Animation_FocusTextureFade</include>
 						</control>
-						<control type="image">
+						<control type="multiimage">
 							<left>60</left>
 							<top>108</top>
 							<width>130</width>
 							<height>130</height>
-							<texture>$INFO[ListItem.Icon]</texture>
+							<imagepath>$INFO[ListItem.Icon]</imagepath>
+							<aspectratio>keep</aspectratio>
+							<timeperimage>20</timeperimage>
+							<fadetime>10</fadetime>
+							<randomize>false</randomize>
 						</control>
 						<control type="label">
 							<left>15</left>
@@ -753,7 +761,7 @@
 	<include name="HourlyItems">
 		<content>
 			<item>
-				<icon>resource://resource.images.weathericons.default/na.png</icon>
+				<icon>$VAR[WeatherOutlookIconPrefixVar]na$VAR[WeatherOutlookIconPostfixVar]</icon>
 				<onclick>noop</onclick>
 				<visible>String.IsEmpty(Weather.Data(Hourly.IsFetched))</visible>
 			</item>
@@ -834,7 +842,7 @@
 	<include name="DailyItems">
 		<content>
 			<item>
-				<icon>resource://resource.images.weathericons.default/na.png</icon>
+				<icon>$VAR[WeatherOutlookIconPrefixVar]na$VAR[WeatherOutlookIconPostfixVar]</icon>
 				<onclick>noop</onclick>
 				<visible>!Weather.IsFetched</visible>
 			</item>
@@ -912,7 +920,7 @@
 			<property name="Cloudiness">$INFO[Weather.Data(Hourly.$PARAM[item_index].Cloudiness)]</property>
 			<property name="ShortDate">$INFO[Weather.Data(Hourly.$PARAM[item_index].ShortDate)]</property>
 			<property name="FanartCode">$INFO[Weather.Data(Hourly.$PARAM[item_index].FanartCode)]</property>
-			<thumb>resource://resource.images.weathericons.default/$INFO[Weather.Data(Hourly.$PARAM[item_index].OutlookIcon)]</thumb>
+			<icon>$VAR[WeatherOutlookIconPrefixVar]$INFO[Weather.Data(Hourly.$PARAM[item_index].FanartCode)]$VAR[WeatherOutlookIconPostfixVar]</icon>
 			<onclick>noop</onclick>
 			<visible>!String.IsEmpty(Weather.Data(Hourly.$PARAM[item_index].Outlook))</visible>
 		</item>
@@ -927,7 +935,7 @@
 			<property name="Outlook">$INFO[Weather.Data(Daily.$PARAM[item_index].Outlook)]</property>
 			<property name="ShortDate">$INFO[Weather.Data(Daily.$PARAM[item_index].ShortDate)]</property>
 			<property name="FanartCode">$INFO[Weather.Data(Daily.$PARAM[item_index].FanartCode)]</property>
-			<thumb>resource://resource.images.weathericons.default/$INFO[Weather.Data(Daily.$PARAM[item_index].OutlookIcon)]</thumb>
+			<icon>$VAR[WeatherOutlookIconPrefixVar]$INFO[Weather.Data(Daily.$PARAM[item_index].FanartCode)]$VAR[WeatherOutlookIconPostfixVar]</icon>
 			<onclick>noop</onclick>
 			<visible>!String.IsEmpty(Weather.Data(Daily.IsFetched)) + !String.IsEmpty(Weather.Data(Daily.$PARAM[item_index].Outlook))</visible>
 		</item>
@@ -942,7 +950,7 @@
 			<property name="Outlook"></property>
 			<property name="ShortDate"></property>
 			<property name="FanartCode">$INFO[Weather.Data(Day$PARAM[item_index].FanartCode)]</property>
-			<thumb>$INFO[Weather.Data(Day$PARAM[item_index].OutlookIcon)]</thumb>
+			<icon>$VAR[WeatherOutlookIconPrefixVar]$INFO[Weather.Data(Day$PARAM[item_index].FanartCode)]$VAR[WeatherOutlookIconPostfixVar]</icon>
 			<onclick>noop</onclick>
 			<visible>String.IsEmpty(Weather.Data(Daily.IsFetched)) + !String.IsEmpty(Weather.Data(Day$PARAM[item_index].Outlook))</visible>
 		</item>

--- a/addons/skin.estuary/xml/Includes_Home.xml
+++ b/addons/skin.estuary/xml/Includes_Home.xml
@@ -935,7 +935,7 @@
 	<include name="WeatherDayItem">
 		<item>
 			<label>$INFO[Weather.Data(Day$PARAM[item_index].Title)]</label>
-			<label2>[COLOR blue]$INFO[Weather.Data(Day$PARAM[item_index].LowTemp)]$INFO[System.TemperatureUnits][/COLOR] ∙ [COLOR red]$INFO[Weather.Data(Day$PARAM[item_index].HighTemp)]$INFO[System.TemperatureUnits][/COLOR]</label2>
+			<label2>[COLOR blue]$INFO[Weather.Data(Day$PARAM[item_index].LowTemp)][/COLOR] ∙ [COLOR red]$INFO[Weather.Data(Day$PARAM[item_index].HighTemp)][/COLOR]</label2>
 			<property name="LongDay"></property>
 			<property name="TempDay"></property>
 			<property name="Cloudiness"></property>

--- a/addons/skin.estuary/xml/MyWeather.xml
+++ b/addons/skin.estuary/xml/MyWeather.xml
@@ -125,6 +125,18 @@
 					<font>font14</font>
 					<width>630</width>
 				</control>
+				<control type="label">
+					<right>100</right>
+					<top>265</top>
+					<aligny>center</aligny>
+					<height>24</height>
+					<width>1000</width>
+					<align>right</align>
+					<font>font10</font>
+					<label>$LOCALIZE[12014]: $INFO[Weather.LastUpdated]</label>
+					<visible>Control.HasFocus(20) + !String.IsEmpty(Weather.LastUpdated)</visible>
+					<animation effect="fade" time="400">VisibleChange</animation>
+				</control>
 				<control type="grouplist">
 					<top>154</top>
 					<left>90</left>

--- a/addons/skin.estuary/xml/MyWeather.xml
+++ b/addons/skin.estuary/xml/MyWeather.xml
@@ -122,7 +122,7 @@
 					<right>400</right>
 					<top>164</top>
 					<align>right</align>
-					<label>[I]$LOCALIZE[402]: $INFO[Weather.Data(Current.FeelsLike)][/I][CR]$INFO[Weather.Data(Current.Condition)]</label>
+					<label>$INFO[Weather.Data(Current.FeelsLike),$LOCALIZE[402] ][CR]$INFO[Weather.Data(Current.Condition)]</label>
 					<font>font14</font>
 					<width>630</width>
 				</control>

--- a/addons/skin.estuary/xml/MyWeather.xml
+++ b/addons/skin.estuary/xml/MyWeather.xml
@@ -68,7 +68,7 @@
 			<scrolltime tween="cubic" easing="out">500</scrolltime>
 			<include>OpenClose_Right</include>
 			<itemgap>-160</itemgap>
-			<visible>!String.StartsWith(Weather.Data(Current.Temperature),$LOCALIZE[503])</visible>
+			<visible>!Weather.IsUpdating</visible>
 			<control type="group" id="567">
 				<description>Weather info</description>
 				<height>410</height>
@@ -206,7 +206,7 @@
 		</include>
 		<include>BottomBar</include>
 		<control type="group">
-			<visible>String.StartsWith(Weather.Data(Current.Temperature),$LOCALIZE[503])</visible>
+			<visible>Weather.IsUpdating</visible>
 			<animation effect="fade" time="400">VisibleChange</animation>
 			<control type="image">
 				<texture>colors/black.png</texture>

--- a/addons/skin.estuary/xml/MyWeather.xml
+++ b/addons/skin.estuary/xml/MyWeather.xml
@@ -68,7 +68,6 @@
 			<scrolltime tween="cubic" easing="out">500</scrolltime>
 			<include>OpenClose_Right</include>
 			<itemgap>-160</itemgap>
-			<visible>!Weather.IsUpdating</visible>
 			<control type="group" id="567">
 				<description>Weather info</description>
 				<height>410</height>

--- a/addons/skin.estuary/xml/MyWeather.xml
+++ b/addons/skin.estuary/xml/MyWeather.xml
@@ -116,14 +116,13 @@
 					<width>300</width>
 					<align>right</align>
 					<font>WeatherTemp</font>
-					<label>$INFO[Weather.Data(Current.Temperature)]$INFO[System.TemperatureUnits]</label>
-					<visible>![String.IsEmpty(Weather.Data(Current.Temperature))]</visible>
+					<label>$INFO[Weather.Data(Current.Temperature)]</label>
 				</control>
 				<control type="label">
 					<right>400</right>
 					<top>164</top>
 					<align>right</align>
-					<label>[I]$LOCALIZE[402]: $INFO[Weather.Data(Current.FeelsLike)]$INFO[System.TemperatureUnits][/I][CR]$INFO[Weather.Data(Current.Condition)]</label>
+					<label>[I]$LOCALIZE[402]: $INFO[Weather.Data(Current.FeelsLike)][/I][CR]$INFO[Weather.Data(Current.Condition)]</label>
 					<font>font14</font>
 					<width>630</width>
 				</control>

--- a/addons/skin.estuary/xml/SkinSettings.xml
+++ b/addons/skin.estuary/xml/SkinSettings.xml
@@ -129,6 +129,14 @@
 					<onclick condition="System.HasAddon(script.image.resource.select) + !System.AddonIsEnabled(script.image.resource.select)">EnableAddon(script.image.resource.select)</onclick>
 					<onclick condition="!System.HasAddon(script.image.resource.select)">InstallAddon(script.image.resource.select)</onclick>
 				</control>
+				<control type="button" id="6068">
+					<label>$LOCALIZE[31177]</label>
+					<label2>$INFO[Skin.String(WeatherOutlookIcon.name)]</label2>
+					<include>DefaultSettingButton</include>
+					<onclick condition="System.AddonIsEnabled(script.image.resource.select)">RunScript(script.image.resource.select,property=WeatherOutlookIcon&amp;type=resource.images.weathericons)</onclick>
+					<onclick condition="System.HasAddon(script.image.resource.select) + !System.AddonIsEnabled(script.image.resource.select)">EnableAddon(script.image.resource.select)</onclick>
+					<onclick condition="!System.HasAddon(script.image.resource.select)">InstallAddon(script.image.resource.select)</onclick>
+				</control>
 				<control type="radiobutton" id="6067">
 					<label>$LOCALIZE[31168]</label>
 					<include>DefaultSettingButton</include>

--- a/addons/skin.estuary/xml/Variables.xml
+++ b/addons/skin.estuary/xml/Variables.xml
@@ -988,4 +988,12 @@
 		<value condition="String.IsEqual(ListItem.Property(stream.isforced),true)">$LOCALIZE[39106]</value>
 		<value condition="String.IsEqual(ListItem.Property(stream.isoriginal),true)">$LOCALIZE[39111]</value>
 	</variable>
+	<variable name="WeatherOutlookIconPrefixVar">
+		<value condition="!String.IsEmpty(Skin.String(WeatherOutlookIcon.path))">$INFO[Skin.String(WeatherOutlookIcon.path)]</value>
+		<value>resource://resource.images.weathericons.default/</value>
+	</variable>
+	<variable name="WeatherOutlookIconPostfixVar">
+		<value condition="!String.IsEmpty(Skin.String(WeatherOutlookIcon.path))">$INFO[Skin.String(WeatherOutlookIcon.ext)]</value>
+		<value>.png</value>
+	</variable>
 </includes>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1171,6 +1171,13 @@ constexpr std::array<InfoMap, 13> player_process = {{
 ///     @return **True** if the weather data has been downloaded.
 ///     <p>
 ///   }
+///   \table_row3{   <b>`Weather.IsUpdating`</b>,
+///                  \anchor Weather_IsUpdating
+///                  _boolean_,
+///     @return **True** if weather data are currently updating.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link Weather_IsUpdating `Weather.IsUpdating`\endlink
+///   }
 ///   \table_row3{   <b>`Weather.Data(property)`</b>,
 ///                  \anchor Weather_Data
 ///                  _string_,
@@ -1218,8 +1225,9 @@ constexpr std::array<InfoMap, 13> player_process = {{
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-constexpr std::array<InfoMap, 8> weather = {{
+constexpr std::array<InfoMap, 9> weather = {{
     {"isfetched",       WEATHER_IS_FETCHED},
+    {"isupdating",      WEATHER_IS_UPDATING},
     {"data",            WEATHER_DATA}, // labels from here
     {"conditions",      WEATHER_CONDITIONS_TEXT},
     {"temperature",     WEATHER_TEMPERATURE},

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1178,6 +1178,13 @@ constexpr std::array<InfoMap, 13> player_process = {{
 ///     <p><hr>
 ///     @skinning_v22 **[New Infolabel]** \link Weather_IsUpdating `Weather.IsUpdating`\endlink
 ///   }
+///   \table_row3{   <b>`Weather.LastUpdated`</b>,
+///                  \anchor Weather_LastUpdated
+///                  _string_,
+///     @return The localized date and time the weather data was last updated, empty string if not available.
+///     <p><hr>
+///     @skinning_v22 **[New Infolabel]** \link Weather_LastUpdated `Weather.LastUpdated`\endlink
+///   }
 ///   \table_row3{   <b>`Weather.Data(property)`</b>,
 ///                  \anchor Weather_Data
 ///                  _string_,
@@ -1225,10 +1232,11 @@ constexpr std::array<InfoMap, 13> player_process = {{
 ///
 /// -----------------------------------------------------------------------------
 // clang-format off
-constexpr std::array<InfoMap, 9> weather = {{
+constexpr std::array<InfoMap, 10> weather = {{
     {"isfetched",       WEATHER_IS_FETCHED},
     {"isupdating",      WEATHER_IS_UPDATING},
-    {"data",            WEATHER_DATA}, // labels from here
+    {"lastupdated",     WEATHER_LAST_UPDATED}, // labels from here
+    {"data",            WEATHER_DATA},
     {"conditions",      WEATHER_CONDITIONS_TEXT},
     {"temperature",     WEATHER_TEMPERATURE},
     {"location",        WEATHER_LOCATION},

--- a/xbmc/ServiceManager.cpp
+++ b/xbmc/ServiceManager.cpp
@@ -168,7 +168,7 @@ bool CServiceManager::InitStageTwo(const std::string& profilesUserDataFolder)
   m_powerManager->Initialize();
   m_powerManager->SetDefaults();
 
-  m_weatherManager = std::make_unique<CWeatherManager>();
+  m_weatherManager = std::make_unique<CWeatherManager>(*m_addonMgr);
 
   m_mediaManager = std::make_unique<CMediaManager>();
   m_mediaManager->Initialize();

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -98,7 +98,8 @@ constexpr uint32_t PLAYER_IS_EXTERNAL                = 86;
 constexpr uint32_t PLAYER_IS_LIVE                    = 87;
 
 constexpr uint32_t WEATHER_DATA                      = 95;
-// unused id 96 to 99
+constexpr uint32_t WEATHER_IS_UPDATING               = 96;
+// unused id 97 to 99
 constexpr uint32_t WEATHER_CONDITIONS_TEXT           = 100;
 constexpr uint32_t WEATHER_TEMPERATURE               = 101;
 constexpr uint32_t WEATHER_LOCATION                  = 102;

--- a/xbmc/guilib/guiinfo/GUIInfoLabels.h
+++ b/xbmc/guilib/guiinfo/GUIInfoLabels.h
@@ -99,7 +99,8 @@ constexpr uint32_t PLAYER_IS_LIVE                    = 87;
 
 constexpr uint32_t WEATHER_DATA                      = 95;
 constexpr uint32_t WEATHER_IS_UPDATING               = 96;
-// unused id 97 to 99
+constexpr uint32_t WEATHER_LAST_UPDATED              = 97;
+// unused id 98 to 99
 constexpr uint32_t WEATHER_CONDITIONS_TEXT           = 100;
 constexpr uint32_t WEATHER_TEMPERATURE               = 101;
 constexpr uint32_t WEATHER_LOCATION                  = 102;

--- a/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
@@ -36,6 +36,9 @@ bool CWeatherGUIInfo::GetLabel(std::string& value, const CFileItem *item, int co
     case WEATHER_DATA:
       value = CServiceBroker::GetWeatherManager().GetProperty(info.GetData3());
       return true;
+    case WEATHER_LAST_UPDATED:
+      value = CServiceBroker::GetWeatherManager().GetLastUpdateTime();
+      return true;
     case WEATHER_CONDITIONS_TEXT:
       value = CServiceBroker::GetWeatherManager().GetInfo(WEATHER_LABEL_CURRENT_COND);
       StringUtils::Trim(value);

--- a/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
+++ b/xbmc/guilib/guiinfo/WeatherGUIInfo.cpp
@@ -80,6 +80,10 @@ bool CWeatherGUIInfo::GetBool(bool& value, const CGUIListItem *gitem, int contex
     case WEATHER_IS_FETCHED:
       value = CServiceBroker::GetWeatherManager().IsFetched();
       return true;
+    case WEATHER_IS_UPDATING:
+      value = CServiceBroker::GetWeatherManager().IsUpdating();
+      return true;
+
     default:
       break;
   }

--- a/xbmc/guilib/listproviders/StaticProvider.cpp
+++ b/xbmc/guilib/listproviders/StaticProvider.cpp
@@ -80,9 +80,20 @@ bool CStaticListProvider::Update(bool forceRefresh)
       i->UpdateProperties(GetParentId());
   }
 
+  bool visibilityChanged{false};
   for (const auto& i : m_items)
-    changed |= i->UpdateVisibility(GetParentId());
+  {
+    if (i->UpdateVisibility(GetParentId()))
+    {
+      visibilityChanged = true;
+      i->UpdateProperties(GetParentId());
+    }
+  }
 
+  if (visibilityChanged)
+    m_updateTime = CTimeUtils::GetFrameTime();
+
+  changed |= visibilityChanged;
   return changed; //! @todo Also returned changed if properties are changed (if so, need to update scroll to letter).
 }
 

--- a/xbmc/utils/InfoLoader.h
+++ b/xbmc/utils/InfoLoader.h
@@ -20,6 +20,7 @@ public:
 
   std::string GetInfo(int info);
   void Refresh();
+  bool IsUpdating() const { return m_busy; }
 
   void OnJobComplete(unsigned int jobID, bool success, CJob *job) override;
 protected:

--- a/xbmc/weather/CMakeLists.txt
+++ b/xbmc/weather/CMakeLists.txt
@@ -1,11 +1,14 @@
 set(SOURCES GUIWindowWeather.cpp
             WeatherJob.cpp
             WeatherManager.cpp
+            WeatherPropertyHelper.cpp
             WeatherTokenLocalizer.cpp)
 
 set(HEADERS GUIWindowWeather.h
             WeatherJob.h
             WeatherManager.h
+            WeatherProperties.h
+            WeatherPropertyHelper.h
             WeatherTokenLocalizer.h)
 
 core_add_library(weather)

--- a/xbmc/weather/WeatherJob.cpp
+++ b/xbmc/weather/WeatherJob.cpp
@@ -26,8 +26,11 @@
 #include "utils/URIUtils.h"
 #include "utils/XTimeUtils.h"
 #include "utils/log.h"
+#include "weather/WeatherProperties.h"
+#include "weather/WeatherPropertyHelper.h"
 
 using namespace ADDON;
+using namespace KODI::WEATHER;
 using namespace std::chrono_literals;
 
 CWeatherJob::CWeatherJob(int location) : m_location(location)
@@ -71,7 +74,11 @@ bool CWeatherJob::DoWork()
 
     CLog::Log(LOGINFO, "WEATHER: Successfully downloaded weather");
 
+    const CDateTime time{CDateTime::GetCurrentDateTime()};
+    m_info.lastUpdateTime = time.GetAsLocalizedDateTime(false, false);
+
     SetFromProperties();
+    SetFromPropertiesV2();
 
     // and send a message that we're done
     CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_WEATHER_FETCHED);
@@ -86,6 +93,11 @@ bool CWeatherJob::DoWork()
 const WeatherInfo& CWeatherJob::GetInfo() const
 {
   return m_info;
+}
+
+const CWeatherManager::WeatherInfoV2& CWeatherJob::GetInfoV2() const
+{
+  return m_infoV2;
 }
 
 namespace
@@ -103,6 +115,59 @@ void FormatTemperature(std::string& text, double temp)
   const CTemperature temperature{CTemperature::CreateFromCelsius(temp)};
   text = StringUtils::Format("{:.0f}", temperature.To(g_langInfo.GetTemperatureUnit()));
 }
+
+class CWeatherPropertyWriter
+{
+public:
+  CWeatherPropertyWriter(CGUIWindow& window,
+                         CWeatherTokenLocalizer& localizer,
+                         CWeatherManager::WeatherInfoV2& info)
+    : m_propReader(window, localizer),
+      m_propSink(info)
+  {
+  }
+
+  CWeatherPropertyHelper::Property Write(const CWeatherPropertyHelper::PropertyName& propName,
+                                         const CWeatherPropertyHelper::PropertyValue& propValue)
+  {
+    m_propSink.try_emplace(propName, propValue);
+    return {propName, propValue};
+  }
+
+  CWeatherPropertyHelper::Property Write(const CWeatherPropertyHelper::PropertyName& propName)
+  {
+    const auto& [name, value] = m_propReader.GetProperty(propName);
+    return Write(name, value);
+  }
+
+  CWeatherPropertyHelper::Property WriteDay(int index,
+                                            const CWeatherPropertyHelper::PropertyName& propName)
+  {
+    const auto& [name, value] = m_propReader.GetDayProperty(index, propName);
+    return Write(name, value);
+  }
+
+  CWeatherPropertyHelper::Property WriteDaily(int index,
+                                              const CWeatherPropertyHelper::PropertyName& propName)
+  {
+    const auto& [name, value] = m_propReader.GetDailyProperty(index, propName);
+    return Write(name, value);
+  }
+
+  CWeatherPropertyHelper::Property WriteHourly(int index,
+                                               const CWeatherPropertyHelper::PropertyName& propName)
+  {
+    const auto& [name, value] = m_propReader.GetHourlyProperty(index, propName);
+    return Write(name, value);
+  }
+
+  const CWeatherPropertyHelper& GetPropertyReader() const { return m_propReader; }
+
+private:
+  CWeatherPropertyHelper m_propReader;
+  CWeatherManager::WeatherInfoV2& m_propSink;
+};
+
 } // unnamed namespace
 
 void CWeatherJob::SetFromProperties()
@@ -110,8 +175,6 @@ void CWeatherJob::SetFromProperties()
   CGUIWindow* window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_WEATHER);
   if (window)
   {
-    const CDateTime time{CDateTime::GetCurrentDateTime()};
-    m_info.lastUpdateTime = time.GetAsLocalizedDateTime(false, false);
     m_info.currentConditions =
         m_localizer.LocalizeOverview(window->GetProperty("Current.Condition").asString());
     m_info.currentIcon = ConstructPath(window->GetProperty("Current.OutlookIcon").asString());
@@ -165,5 +228,148 @@ void CWeatherJob::SetFromProperties()
       m_info.forecast[i].m_overview =
           m_localizer.LocalizeOverview(window->GetProperty(strDay).asString());
     }
+  }
+}
+
+void CWeatherJob::SetFromPropertiesV2()
+{
+  CGUIComponent* gui{CServiceBroker::GetGUI()};
+  if (gui == nullptr)
+    return;
+
+  CGUIWindow* window{gui->GetWindowManager().GetWindow(WINDOW_WEATHER)};
+  if (window == nullptr)
+    return;
+
+  CWeatherPropertyWriter props{*window, m_localizer, m_infoV2};
+
+  // Data for current conditions
+
+  props.Write(CURRENT_LOCATION);
+  props.Write(CURRENT_CONDITION);
+  props.Write(CURRENT_TEMPERATURE);
+  props.Write(CURRENT_FEELS_LIKE);
+  props.Write(CURRENT_DEW_POINT);
+  props.Write(CURRENT_HUMIDITY);
+  props.Write(CURRENT_PRECIPITATION);
+  props.Write(CURRENT_CLOUDINESS);
+  props.Write(CURRENT_UV_INDEX);
+
+  {
+    const auto& [iconProp, iconValue] = props.Write(CURRENT_OUTLOOK_ICON);
+    props.Write(CURRENT_CONDITION_ICON, iconValue); // See spec.
+
+    // If not provided by the add-on, create fanart code from outlook icon file name.
+    const auto& [fanartCodeProp, fanartCodeValue] =
+        props.GetPropertyReader().GetProperty(CURRENT_FANART_CODE);
+    props.Write(fanartCodeProp,
+                CWeatherPropertyHelper::FormatFanartCode(fanartCodeValue, iconValue));
+  }
+
+  {
+    const auto& [directionProp, directionValue] = props.Write(CURRENT_WIND_DIRECTION);
+
+    // Special casing: Combine window props Current.Wind and Current.WindDirection values, store
+    // the result in Current.Wind, store original value of Current.Wind in Current.WindSpeed.
+    // See spec.
+    const auto& [windProp, speedValue] = props.GetPropertyReader().GetProperty(CURRENT_WIND);
+    const CSpeed speed{
+        CSpeed::CreateFromKilometresPerHour(std::strtod(speedValue.c_str(), nullptr))};
+    props.Write(windProp, CWeatherPropertyHelper::FormatWind(directionValue, speed));
+    props.Write(CURRENT_WIND_SPEED, CWeatherPropertyHelper::FormatWind("", speed));
+  }
+
+  // Data for a week
+
+  for (unsigned int i = 0; i < WeatherInfo::NUM_DAYS; ++i)
+  {
+    props.WriteDay(i, DAY_TITLE);
+    props.WriteDay(i, DAY_OUTLOOK);
+    props.WriteDay(i, DAY_HIGH_TEMP);
+    props.WriteDay(i, DAY_LOW_TEMP);
+
+    {
+      const auto& [iconProp, iconValue] = props.WriteDay(i, DAY_OUTLOOK_ICON);
+
+      // If not provided by the add-on, create fanart code from outlook icon file name.
+      const auto& [fanartCodeProp, fanartCodeValue] =
+          props.GetPropertyReader().GetDayProperty(i, DAY_FANART_CODE);
+      props.Write(fanartCodeProp,
+                  CWeatherPropertyHelper::FormatFanartCode(fanartCodeValue, iconValue));
+    }
+  }
+
+  // Hourly data
+
+  int idx{1};
+  while (true)
+  {
+    if (!props.GetPropertyReader().HasHourlyProperties(idx))
+      break; // done, no more data
+
+    props.WriteHourly(idx, HOURLY_TIME);
+    props.WriteHourly(idx, HOURLY_LONG_DATE);
+    props.WriteHourly(idx, HOURLY_SHORT_DATE);
+    props.WriteHourly(idx, HOURLY_OUTLOOK);
+    props.WriteHourly(idx, HOURLY_TEMPERATURE);
+    props.WriteHourly(idx, HOURLY_DEW_POINT);
+    props.WriteHourly(idx, HOURLY_FEELS_LIKE);
+    props.WriteHourly(idx, HOURLY_HUMIDITY);
+    props.WriteHourly(idx, HOURLY_PRECIPITATION);
+    props.WriteHourly(idx, HOURLY_PRESSURE);
+    props.WriteHourly(idx, HOURLY_WIND_SPEED);
+    props.WriteHourly(idx, HOURLY_WIND_DIRECTION);
+
+    {
+      const auto& [iconProp, iconValue] = props.WriteHourly(idx, HOURLY_OUTLOOK_ICON);
+
+      // If not provided by the add-on, create fanart code from outlook icon file name.
+      const auto& [fanartCodeProp, fanartCodeValue] =
+          props.GetPropertyReader().GetHourlyProperty(idx, HOURLY_FANART_CODE);
+      props.Write(fanartCodeProp,
+                  CWeatherPropertyHelper::FormatFanartCode(fanartCodeValue, iconValue));
+    }
+
+    idx++;
+  }
+
+  // Daily data
+
+  idx = 1;
+  while (true)
+  {
+    if (!props.GetPropertyReader().HasDailyProperties(idx))
+      break; // done, no more data
+
+    props.WriteDaily(idx, DAILY_SHORT_DATE);
+    props.WriteDaily(idx, DAILY_SHORT_DAY);
+    props.WriteDaily(idx, DAILY_OUTLOOK);
+    props.WriteDaily(idx, DAILY_HIGH_TEMPERATURE);
+    props.WriteDaily(idx, DAILY_LOW_TEMPERATURE);
+    props.WriteDaily(idx, DAILY_PRECIPITATION);
+    props.WriteDaily(idx, DAILY_WIND_SPEED);
+    props.WriteDaily(idx, DAILY_WIND_DIRECTION);
+
+    {
+      const auto& [iconProp, iconValue] = props.WriteDaily(idx, DAILY_OUTLOOK_ICON);
+
+      // If not provided by the add-on, create fanart code from outlook icon file name.
+      const auto& [fanartCodeProp, fanartCodeValue] =
+          props.GetPropertyReader().GetDailyProperty(idx, DAILY_FANART_CODE);
+      props.Write(fanartCodeProp,
+                  CWeatherPropertyHelper::FormatFanartCode(fanartCodeValue, iconValue));
+    }
+
+    idx++;
+  }
+
+  // Locations
+
+  const auto& [prop, value] = props.Write(GENERAL_LOCATIONS);
+
+  const int locations{std::atoi(value.c_str())};
+  for (int i = 1; i <= locations; ++i)
+  {
+    props.Write(StringUtils::Format(GENERAL_LOCATION_WITH_INDEX, i));
   }
 }

--- a/xbmc/weather/WeatherJob.h
+++ b/xbmc/weather/WeatherJob.h
@@ -20,11 +20,14 @@ public:
   bool DoWork() override;
 
   const WeatherInfo& GetInfo() const;
+  const CWeatherManager::WeatherInfoV2& GetInfoV2() const;
 
 private:
   void SetFromProperties();
+  void SetFromPropertiesV2();
 
-  WeatherInfo m_info;
+  WeatherInfo m_info{};
+  CWeatherManager::WeatherInfoV2 m_infoV2{};
   CWeatherTokenLocalizer m_localizer;
   int m_location{-1};
 };

--- a/xbmc/weather/WeatherManager.cpp
+++ b/xbmc/weather/WeatherManager.cpp
@@ -10,6 +10,7 @@
 
 #include "ServiceBroker.h"
 #include "WeatherJob.h"
+#include "addons/AddonEvents.h"
 #include "addons/AddonManager.h"
 #include "addons/addoninfo/AddonType.h"
 #include "addons/gui/GUIDialogAddonSettings.h"
@@ -29,14 +30,53 @@
 using namespace ADDON;
 using namespace KODI::WEATHER;
 
-CWeatherManager::CWeatherManager() : CInfoLoader(30 * 60 * 1000) // 30 minutes
+CWeatherManager::CWeatherManager(ADDON::CAddonMgr& addonManager)
+  : CInfoLoader(30 * 60 * 1000), // 30 minutes
+    m_addonManager(addonManager)
 {
-  CServiceBroker::GetSettingsComponent()->GetSettings()->GetSettingsManager()->RegisterCallback(
-      this, {CSettings::SETTING_WEATHER_ADDON, CSettings::SETTING_WEATHER_ADDONSETTINGS});
+  const auto settingsComponent = CServiceBroker::GetSettingsComponent();
+  if (settingsComponent)
+  {
+    std::shared_ptr<CSettings> settings = settingsComponent->GetSettings();
+    if (settings)
+    {
+      // Register settings callback
+      settings->GetSettingsManager()->RegisterCallback(
+          this, {CSettings::SETTING_WEATHER_ADDON, CSettings::SETTING_WEATHER_ADDONSETTINGS});
+
+      // At startup, if current weather add-on isn't available, reset the setting
+      const std::string addonId = settings->GetString(CSettings::SETTING_WEATHER_ADDON);
+      if (!addonId.empty() && (addonManager.IsAddonDisabled(addonId) || !addonManager.IsAddonInstalled(addonId)))
+      {
+        settings->SetString(CSettings::SETTING_WEATHER_ADDON, "");
+        settings->Save();
+      }
+
+      // Handle add-on becoming unavailable
+      m_addonManager.Events().Subscribe(
+          this,
+          [settings = std::move(settings)](const AddonEvent& event)
+          {
+            if (typeid(event) == typeid(AddonEvents::Disabled) || // not called on uninstall
+                typeid(event) == typeid(AddonEvents::UnInstalled))
+            {
+              // If add-on was the current weather add-on, reset the setting
+              const std::string addonId = event.addonId;
+              if (addonId == settings->GetString(CSettings::SETTING_WEATHER_ADDON))
+              {
+                settings->SetString(CSettings::SETTING_WEATHER_ADDON, "");
+                settings->Save();
+              }
+            }
+        });
+    }
+  }
 }
 
 CWeatherManager::~CWeatherManager()
 {
+  m_addonManager.Events().Unsubscribe(this);
+
   const auto settingsComponent = CServiceBroker::GetSettingsComponent();
   if (!settingsComponent)
     return;
@@ -193,7 +233,7 @@ void CWeatherManager::OnSettingChanged(const std::shared_ptr<const CSetting>& se
     return;
 
   const std::string settingId = setting->GetId();
-  if (settingId == CSettings::SETTING_WEATHER_ADDON)
+  if (settingId == CSettings::SETTING_WEATHER_ADDON && CServiceBroker::GetGUI() != nullptr)
   {
     // clear "WeatherProviderLogo" property that some weather addons set
     CGUIWindow* window = CServiceBroker::GetGUI()->GetWindowManager().GetWindow(WINDOW_WEATHER);

--- a/xbmc/weather/WeatherManager.h
+++ b/xbmc/weather/WeatherManager.h
@@ -12,9 +12,13 @@
 #include "threads/CriticalSection.h"
 #include "utils/InfoLoader.h"
 
+#include <algorithm>
 #include <array>
+#include <map>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <vector>
 
 constexpr unsigned int WEATHER_LABEL_LOCATION = 10;
 constexpr unsigned int WEATHER_IMAGE_CURRENT_ICON = 21;
@@ -65,7 +69,22 @@ public:
    \param property the full name of the property (e.g. Current.Temperature, Hourly.1.Temperature)
    \return the property value
    */
-  std::string GetProperty(const std::string& property);
+  std::string GetProperty(const std::string& property) const;
+
+  /*!
+   \brief Retrieve the value for the given "day" weather property
+   \param index the index for the day, (can be in the range [0..6])
+   \param property the name of the property (e.g. HighTemp)
+   \return the property value
+   */
+  std::string GetDayProperty(unsigned int index, const std::string& property) const;
+
+  /*!
+   \brief Get the city names of all available locations, sorted by location index.
+   \return the city names
+   \sa GetLocation
+   */
+  std::vector<std::string> GetLocations() const;
 
   /*!
    \brief Retrieve the city name for the specified location from the settings
@@ -92,6 +111,19 @@ public:
    */
   static int GetArea();
 
+  struct CaseInsensitiveWeatherCompare
+  {
+    using is_transparent = void; // Enables heterogeneous operations.
+
+    bool operator()(const std::string_view& lhs, const std::string_view& rhs) const
+    {
+      return std::ranges::lexicographical_compare(lhs, rhs, [](char l, char r)
+                                                  { return std::tolower(l) < std::tolower(r); });
+    }
+  };
+
+  using WeatherInfoV2 = std::map<std::string, std::string, CaseInsensitiveWeatherCompare>;
+
 protected:
   CJob* GetJob() const override;
   std::string TranslateInfo(int info) const override;
@@ -104,4 +136,5 @@ protected:
 private:
   mutable CCriticalSection m_critSection;
   WeatherInfo m_info{};
+  mutable WeatherInfoV2 m_infoV2{};
 };

--- a/xbmc/weather/WeatherManager.h
+++ b/xbmc/weather/WeatherManager.h
@@ -20,6 +20,12 @@
 #include <string_view>
 #include <vector>
 
+
+namespace ADDON
+{
+class CAddonMgr;
+} // namespace ADDON
+
 constexpr unsigned int WEATHER_LABEL_LOCATION = 10;
 constexpr unsigned int WEATHER_IMAGE_CURRENT_ICON = 21;
 constexpr unsigned int WEATHER_LABEL_CURRENT_COND = 22;
@@ -61,7 +67,7 @@ struct WeatherInfo
 class CWeatherManager : public CInfoLoader, public ISettingCallback
 {
 public:
-  CWeatherManager();
+  CWeatherManager(ADDON::CAddonMgr& addonManager);
   ~CWeatherManager() override;
 
   /*!
@@ -134,7 +140,13 @@ protected:
   void OnSettingAction(const std::shared_ptr<const CSetting>& setting) override;
 
 private:
+  // Construction parameters
+  ADDON::CAddonMgr& m_addonManager;
+
+  // Synchronization parameters
   mutable CCriticalSection m_critSection;
+
+  // State parameters
   WeatherInfo m_info{};
   mutable WeatherInfoV2 m_infoV2{};
 };

--- a/xbmc/weather/WeatherProperties.h
+++ b/xbmc/weather/WeatherProperties.h
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+namespace KODI::WEATHER
+{
+// Specification: https://kodi.wiki/view/Weather_addons
+
+// Current weather
+constexpr const char* CURRENT_CLOUDINESS = "Current.Cloudiness";
+constexpr const char* CURRENT_CONDITION = "Current.Condition";
+constexpr const char* CURRENT_CONDITION_ICON = "Current.ConditionIcon";
+constexpr const char* CURRENT_DEW_POINT = "Current.DewPoint";
+constexpr const char* CURRENT_FANART_CODE = "Current.FanartCode";
+constexpr const char* CURRENT_FEELS_LIKE = "Current.FeelsLike";
+constexpr const char* CURRENT_HUMIDITY = "Current.Humidity";
+constexpr const char* CURRENT_LOCATION = "Current.Location";
+constexpr const char* CURRENT_OUTLOOK_ICON = "Current.OutlookIcon";
+constexpr const char* CURRENT_PRECIPITATION = "Current.Precipitation";
+constexpr const char* CURRENT_TEMPERATURE = "Current.Temperature";
+constexpr const char* CURRENT_UV_INDEX = "Current.UVIndex";
+constexpr const char* CURRENT_WIND = "Current.Wind";
+constexpr const char* CURRENT_WIND_DIRECTION = "Current.WindDirection";
+constexpr const char* CURRENT_WIND_SPEED = "Current.WindSpeed";
+
+// Daily weather, format #1, weather for up to 7 days
+// Format: Day{0..6}.{property-name}
+constexpr const char* DAY_WITH_INDEX_AND_NAME = "Day{}.{}";
+
+constexpr const char* DAY_FANART_CODE = "FanartCode";
+constexpr const char* DAY_HIGH_TEMP = "HighTemp";
+constexpr const char* DAY_LOW_TEMP = "LowTemp";
+constexpr const char* DAY_OUTLOOK = "Outlook";
+constexpr const char* DAY_OUTLOOK_ICON = "OutlookIcon";
+constexpr const char* DAY_TITLE = "Title";
+
+// Daily weather, format #2
+// Format: Daily.{1-based-index}.{property-name}
+constexpr const char* DAILY_WITH_INDEX_AND_NAME = "Daily.{}.{}";
+
+constexpr const char* DAILY_FANART_CODE = "FanartCode";
+constexpr const char* DAILY_HIGH_TEMPERATURE = "HighTemperature";
+constexpr const char* DAILY_LOW_TEMPERATURE = "LowTemperature";
+constexpr const char* DAILY_OUTLOOK = "Outlook";
+constexpr const char* DAILY_OUTLOOK_ICON = "OutlookIcon";
+constexpr const char* DAILY_PRECIPITATION = "Precipitation";
+constexpr const char* DAILY_SHORT_DATE = "ShortDate";
+constexpr const char* DAILY_SHORT_DAY = "ShortDay";
+constexpr const char* DAILY_WIND_DIRECTION = "WindDirection";
+constexpr const char* DAILY_WIND_SPEED = "WindSpeed";
+
+// Hourly weather
+// Format: Hourly.{1-based-index}.{property-name}
+constexpr const char* HOURLY_WITH_INDEX_AND_NAME = "Hourly.{}.{}";
+
+constexpr const char* HOURLY_DEW_POINT = "DewPoint";
+constexpr const char* HOURLY_FANART_CODE = "FanartCode";
+constexpr const char* HOURLY_FEELS_LIKE = "FeelsLike";
+constexpr const char* HOURLY_HUMIDITY = "Humidity";
+constexpr const char* HOURLY_LONG_DATE = "LongDate";
+constexpr const char* HOURLY_OUTLOOK = "Outlook";
+constexpr const char* HOURLY_OUTLOOK_ICON = "OutlookIcon";
+constexpr const char* HOURLY_PRECIPITATION = "Precipitation";
+constexpr const char* HOURLY_PRESSURE = "Pressure";
+constexpr const char* HOURLY_SHORT_DATE = "ShortDate";
+constexpr const char* HOURLY_TEMPERATURE = "Temperature";
+constexpr const char* HOURLY_TIME = "Time";
+constexpr const char* HOURLY_WIND_DIRECTION = "WindDirection";
+constexpr const char* HOURLY_WIND_SPEED = "WindSpeed";
+
+// General properties
+constexpr const char* GENERAL_LOCATIONS = "Locations";
+constexpr const char* GENERAL_LOCATION_WITH_INDEX = "Location{}"; // Format: Location{1-based-index}
+
+// Weather condition codes
+constexpr const char* CONDITION_CODE_NOT_AVAILABLE = "na";
+
+} // namespace KODI::WEATHER

--- a/xbmc/weather/WeatherPropertyHelper.cpp
+++ b/xbmc/weather/WeatherPropertyHelper.cpp
@@ -1,0 +1,207 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#include "WeatherPropertyHelper.h"
+
+#include "LangInfo.h"
+#include "guilib/GUIWindow.h"
+#include "guilib/LocalizeStrings.h"
+#include "utils/StringUtils.h"
+#include "utils/URIUtils.h"
+#include "utils/Variant.h"
+#include "weather/WeatherProperties.h"
+#include "weather/WeatherTokenLocalizer.h"
+
+#include <functional>
+#include <map>
+#include <string_view>
+
+using namespace KODI::WEATHER;
+
+namespace
+{
+std::string FormatTemperature(const std::string& temperature)
+{
+  if (temperature.empty())
+    return temperature;
+
+  // Convert from celsius to system temperature unit and append resp. unit of measurement.
+  const CTemperature t{CTemperature::CreateFromCelsius(std::strtod(temperature.c_str(), nullptr))};
+  if (!t.IsValid())
+    return temperature;
+
+  return StringUtils::Format("{:.0f}{}", t.To(g_langInfo.GetTemperatureUnit()),
+                             g_langInfo.GetTemperatureUnitString());
+}
+
+std::string FormatWindSpeed(const std::string& speed)
+{
+  if (speed.empty())
+    return speed;
+
+  // Convert from kilometres per hour to system speed unit and append resp. unit of measurement.
+  const CSpeed s{CSpeed::CreateFromKilometresPerHour(std::strtod(speed.c_str(), nullptr))};
+  if (!s.IsValid())
+    return speed;
+
+  return StringUtils::Format("{} {}", static_cast<int>(s.To(g_langInfo.GetSpeedUnit())),
+                             g_langInfo.GetSpeedUnitString());
+}
+
+std::string FormatPercentage(const std::string& percentage)
+{
+  if (percentage.empty())
+    return {};
+
+  if (StringUtils::EndsWith(percentage, "%")) // Some add-ons return value including unit
+    return percentage;
+
+  return StringUtils::Format("{}%", percentage);
+}
+
+enum class LocalizationType
+{
+  NONE,
+  OVERVIEW,
+  OVERVIEW_TOKEN,
+};
+
+struct PropertyDetails
+{
+  std::function<std::string(std::string&)> formatter;
+  LocalizationType l10n{LocalizationType::NONE};
+};
+
+// clang-format off
+const std::map<std::string_view, PropertyDetails> propertyDetails{{
+    {"Temperature",     {FormatTemperature, LocalizationType::NONE}},
+    {"FeelsLike",       {FormatTemperature, LocalizationType::NONE}},
+    {"DewPoint",        {FormatTemperature, LocalizationType::NONE}},
+    {"HighTemp",        {FormatTemperature, LocalizationType::NONE}},
+    {"LowTemp",         {FormatTemperature, LocalizationType::NONE}},
+    {"HighTemperature", {FormatTemperature, LocalizationType::NONE}},
+    {"LowTemperature",  {FormatTemperature, LocalizationType::NONE}},
+    {"WindSpeed",       {FormatWindSpeed,   LocalizationType::NONE}},
+    {"Humidity",        {FormatPercentage,  LocalizationType::NONE}},
+    {"Precipitation",   {FormatPercentage,  LocalizationType::NONE}},
+    {"Cloudiness",      {FormatPercentage,  LocalizationType::NONE}},
+    {"Condition",       {{},                LocalizationType::OVERVIEW}},
+    {"UVIndex",         {{},                LocalizationType::OVERVIEW}},
+    {"Outlook",         {{},                LocalizationType::OVERVIEW}},
+    {"WindDirection",   {{},                LocalizationType::OVERVIEW_TOKEN}},
+    {"Title",           {{},                LocalizationType::OVERVIEW_TOKEN}},
+}};
+// clang-format on
+} // unnamed namespace
+
+CWeatherPropertyHelper::Property CWeatherPropertyHelper::GetProperty(const std::string& prop) const
+{
+  if (prop.empty())
+    return {};
+
+  std::string val{m_window.GetProperty(prop).asString()};
+
+  const size_t pos{prop.find_last_of(".")};
+  if (pos != std::string::npos && pos < (prop.size() - 1))
+  {
+    const auto& it{propertyDetails.find(prop.substr(pos + 1))};
+    if (it != propertyDetails.cend())
+    {
+      const auto& [formatter, l10n] = (*it).second;
+
+      // Need to format the prop?
+      if (formatter)
+        val = formatter(val);
+
+      // Need to localize the prop?
+      if (l10n == LocalizationType::OVERVIEW)
+        val = m_localizer.LocalizeOverview(val);
+      else if (l10n == LocalizationType::OVERVIEW_TOKEN)
+        val = m_localizer.LocalizeOverviewToken(val);
+    }
+  }
+  return {prop, val};
+}
+
+CWeatherPropertyHelper::Property CWeatherPropertyHelper::GetDayProperty(
+    int index, const std::string& prop) const
+{
+  // Note: No '.' after 'Day'. This is different from 'Daily' and 'Hourly'.
+  return GetProperty(StringUtils::Format(DAY_WITH_INDEX_AND_NAME, index, prop));
+}
+
+CWeatherPropertyHelper::Property CWeatherPropertyHelper::GetDailyProperty(
+    int index, const std::string& prop) const
+{
+  return GetProperty(StringUtils::Format(DAILY_WITH_INDEX_AND_NAME, index, prop));
+}
+
+CWeatherPropertyHelper::Property CWeatherPropertyHelper::GetHourlyProperty(
+    int index, const std::string& prop) const
+{
+  return GetProperty(StringUtils::Format(HOURLY_WITH_INDEX_AND_NAME, index, prop));
+}
+
+bool CWeatherPropertyHelper::HasDailyProperties(int index) const
+{
+  // No date value, assume no data for this index.
+  return !m_window
+              .GetProperty(StringUtils::Format(DAILY_WITH_INDEX_AND_NAME, index, DAILY_SHORT_DATE))
+              .asString()
+              .empty();
+}
+
+bool CWeatherPropertyHelper::HasHourlyProperties(int index) const
+{
+  // No time value, assume no data for this index.
+  return !m_window.GetProperty(StringUtils::Format(HOURLY_WITH_INDEX_AND_NAME, index, HOURLY_TIME))
+              .asString()
+              .empty();
+}
+
+std::string CWeatherPropertyHelper::FormatWind(const std::string& direction, const CSpeed& speed)
+{
+  if (direction == "CALM")
+  {
+    return g_localizeStrings.Get(1410); // Calm
+  }
+  else
+  {
+    if (!speed.IsValid())
+      return {};
+
+    if (direction.empty())
+    {
+      return StringUtils::Format("{} {}", speed.To(g_langInfo.GetSpeedUnit()),
+                                 g_langInfo.GetSpeedUnitString());
+    }
+    else
+    {
+      return StringUtils::Format(g_localizeStrings.Get(434), // From {direction} at {speed} {unit}
+                                 direction, static_cast<int>(speed.To(g_langInfo.GetSpeedUnit())),
+                                 g_langInfo.GetSpeedUnitString());
+    }
+  }
+}
+
+std::string CWeatherPropertyHelper::FormatFanartCode(const std::string& fanartCode,
+                                                     const std::string& outlookIcon)
+{
+  if (!fanartCode.empty())
+    return fanartCode; // take what we have
+
+  if (!outlookIcon.empty())
+  {
+    // As fallback, extract code from outlook icon file name
+    std::string code{URIUtils::GetFileName(outlookIcon)};
+    URIUtils::RemoveExtension(code);
+    return code;
+  }
+
+  return CONDITION_CODE_NOT_AVAILABLE;
+}

--- a/xbmc/weather/WeatherPropertyHelper.h
+++ b/xbmc/weather/WeatherPropertyHelper.h
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (C) 2025 Team Kodi
+ *  This file is part of Kodi - https://kodi.tv
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSES/README.md for more information.
+ */
+
+#pragma once
+
+#include <string>
+#include <tuple>
+
+class CGUIWindow;
+class CSpeed;
+class CWeatherTokenLocalizer;
+
+namespace KODI::WEATHER
+{
+class CWeatherPropertyHelper
+{
+public:
+  CWeatherPropertyHelper(CGUIWindow& window, CWeatherTokenLocalizer& localizer)
+    : m_window(window),
+      m_localizer(localizer)
+  {
+  }
+
+  using PropertyName = std::string;
+  using PropertyValue = std::string;
+  using Property = std::tuple<PropertyName, PropertyValue>;
+
+  Property GetProperty(const std::string& prop) const;
+  Property GetDayProperty(int index, const std::string& prop) const;
+  Property GetDailyProperty(int index, const std::string& prop) const;
+  Property GetHourlyProperty(int index, const std::string& prop) const;
+
+  bool HasDailyProperties(int index) const;
+  bool HasHourlyProperties(int index) const;
+
+  static std::string FormatWind(const std::string& direction, const CSpeed& speed);
+  static std::string FormatFanartCode(const std::string& fanartCode,
+                                      const std::string& outlookIcon);
+
+private:
+  const CGUIWindow& m_window;
+  CWeatherTokenLocalizer& m_localizer;
+};
+} // namespace KODI::WEATHER


### PR DESCRIPTION
## Description

Bug: disabling or uninstalling the current weather add-on shows stale or no information:

<img width="1346" height="756" alt="Screenshot 2025-09-04 at 8 11 10 PM" src="https://github.com/user-attachments/assets/3fd83430-6af9-4e6b-94c3-001ccb05d8d1" />

Stale info before restart:

<img width="1343" height="753" alt="Screenshot 2025-09-04 at 7 58 56 PM" src="https://github.com/user-attachments/assets/602aa610-0e21-4c79-b939-fd12cbd19611" />

Empty info after restart:

<img width="1346" height="756" alt="Screenshot 2025-09-04 at 8 26 31 PM" src="https://github.com/user-attachments/assets/81d10a91-2b77-40f3-9fd6-959dbf9b8705" />

Solution: Check for add-on becoming unavailable and reset the setting, so that the user again gets the link to weather settings.

<img width="1345" height="760" alt="Screenshot 2025-09-04 at 7 58 25 PM" src="https://github.com/user-attachments/assets/a1ac65d3-61d2-43aa-86e7-64df51549da4" />

## Motivation and context

For https://github.com/xbmc/xbmc/pull/27212

## Types of change
<!--- What type of change does your code introduce? Put an `x` with no space in all the boxes that apply like this: [X] -->
- [x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **Student submission** (PR was done for educational purposes and will be treated as such)
- [ ] **None of the above** (please explain below)
